### PR TITLE
Remove checks for invalid handlers

### DIFF
--- a/test/trolleybus_test.exs
+++ b/test/trolleybus_test.exs
@@ -34,26 +34,6 @@ defmodule TrolleybusTest do
     end
   end
 
-  defmodule EventWithNonExistentHandler do
-    use Trolleybus.Event
-
-    handler(HandlerThatDoesNotExist)
-
-    message do
-      field(:field1, :string)
-    end
-  end
-
-  defmodule EventWithNonSupportingHandler do
-    use Trolleybus.Event
-
-    handler(TrolleybusTest.Handler1)
-
-    message do
-      field(:field1, :string)
-    end
-  end
-
   defmodule Handler1 do
     use Trolleybus.Handler
 
@@ -140,18 +120,6 @@ defmodule TrolleybusTest do
                array_field: [%SomeStruct{}],
                explode?: true
              } = event
-    end
-
-    test "fails for non-existent handler in event definition" do
-      assert_raise Trolleybus.Event.Error, ~r/are not valid handlers/, fn ->
-        Trolleybus.publish(%EventWithNonExistentHandler{field1: "foo"})
-      end
-    end
-
-    test "fails for a hadler missing clause for the event" do
-      assert_raise Trolleybus.Event.Error, ~r/are missing clause for the event/, fn ->
-        Trolleybus.publish(%EventWithNonSupportingHandler{field1: "foo"})
-      end
     end
 
     test "fails for event failing validation" do


### PR DESCRIPTION
Remove conditions that check if handlers are valid handlers for an event.

`validate_handlers/2` first checks if `__handled_events__` function is defined in each of the handlers and then checks if all handlers handle the event.
However, at the time of checking if `__handled_events__` function is defined, the handler module may not be loaded. This will cause the function `validate_handlers/2` to return incorrect falsy result.

Since the checks that `validate handlers` happen at run-time, this does not provide much more value compared to just letting it crash. That is why `validate_handlers/2` function is entirely removed from the code.
